### PR TITLE
Fix Interval Calculation

### DIFF
--- a/redux/ActionCreators.js
+++ b/redux/ActionCreators.js
@@ -1103,7 +1103,10 @@ export const setListenerInterval = (
         console.log(alertTime.afterNow === alertTime.afterCheckin)
 
         // TODO: Fix the following to account for snooze.
-        if (alertTime.beforeCheckin === alertTime.afterCheckin) {
+        if ((moment(now) - moment(checkinTime)) > 86400000) {
+          dispatch(setTimerIntervalFulfilledAction(0))
+          return 0
+        } else if (alertTime.beforeCheckin === alertTime.afterCheckin) {
           if (nowMinutes > checkinMinutes) {
             if (alertTime.afterCheckin > nowMinutes) {
               const interval = (alertTime.afterCheckin - nowMinutes)
@@ -1399,7 +1402,10 @@ export const setTimerInterval = (
         console.log(alertTime.beforeNow === alertTime.beforeCheckin)
         console.log(alertTime.afterNow === alertTime.afterCheckin)
 
-        if (alertTime.beforeCheckin === alertTime.afterCheckin) {
+        if ((moment(now) - moment(checkinTime)) > 86400000) {
+          dispatch(setTimerIntervalFulfilledAction(0))
+          return 0
+        } else if (alertTime.beforeCheckin === alertTime.afterCheckin) {
           if (nowMinutes > checkinMinutes) {
             if (alertTime.afterCheckin > nowMinutes) {
               const interval = (alertTime.afterCheckin - nowMinutes)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6589,14 +6589,21 @@ normalize-path@^2.0.1, normalize-path@^2.1.1:
     remove-trailing-separator "^1.0.1"
 
 npm-bundled@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.0.tgz#2e8fdb7e69eff2df963937b696243316537c284b"
-  integrity sha512-ez6dcKBFNo4FvlMqscBEFUum6M2FTLW5grqm3DyBKB5XOyKVCeeWvAuoZtbmW/5Cv8EM2bQUOA6ufxa/TKVN0g==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
+  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+  dependencies:
+    npm-normalize-package-bin "^1.0.1"
+
+npm-normalize-package-bin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz#6e79a41f23fd235c0623218228da7d9c23b8f6e2"
+  integrity sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
 
 npm-packlist@^1.1.6:
-  version "1.4.6"
-  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.6.tgz#53ba3ed11f8523079f1457376dd379ee4ea42ff4"
-  integrity sha512-u65uQdb+qwtGvEJh/DgQgW1Xg7sqeNbmxYyrvlNznaVTjV3E5P6F/EFjM+BVHXl7JJlsdG8A64M0XI8FI/IOlg==
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
+  integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
   dependencies:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"


### PR DESCRIPTION
When the last check-in was more than a day ago, the action creators that
calculate the interval to wait before firing an alert should return
zero.