### PR TITLE
Enclose Promise.all Variables in Array

### DIFF
--- a/redux/ActionCreators.js
+++ b/redux/ActionCreators.js
@@ -653,9 +653,7 @@ export const removeListeners = () => (dispatch, getState) => {
   dispatch(removeListenersRequestedAction())
 
   return Promise.all(
-    getState().patient.listeners.forEach(
-      listener => clearTimeout(listener)
-    )
+    [getState().patient.listeners.forEach(listener => clearTimeout(listener))]
   )
     .then(
       () => { dispatch(removeListenersFulfilledAction()) },
@@ -703,7 +701,7 @@ export const removeTimers = () => (dispatch, getState) => {
   dispatch(removeTimersRequestedAction())
 
   return Promise.all(
-    getState().timer.timers.forEach(timer => clearTimeout(timer))
+    [getState().timer.timers.forEach(timer => clearTimeout(timer))]
   )
     .then(
       () => { dispatch(removeTimersFulfilledAction()) },


### PR DESCRIPTION
Fix Redux Actions by placing Promise.all() variables inside of an array.  Otherwise, the promise stalls.