### PR TITLE
Fix Grabbing of Subscriber Device Tokens to Suit New Format

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -202,9 +202,7 @@ const getRegistrationTokenIfNotCheckedIn = data => {
           ) {
             return {
               forPatient: data.registrationToken,
-              forStandbys: data.subscribers.map(
-                subscriber => subscriber.registrationTokens
-              ).reduce((acc, val) => acc.concat(val), [])
+              forStandbys: [].concat.apply([], Object.values(data.subscribers))
             }
           } else {
             return {


### PR DESCRIPTION
The format for the standby/buddy device tokens in the Firestore has changed.  This request fixes the way the Firebase Function grabs that data for sending push notifications to buddy devices.