### PR TITLE
Add Condition That Checks If Alerts Were Sent

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -48,9 +48,24 @@ exports.checkCheckins = functions.pubsub.schedule(
           querySnapshot.forEach(
             doc => {
               // doc.data() is never undefined for query doc snapshots
-              deviceTokens.add(
-                getDeviceTokensIfNotCheckedIn(doc.data())
-              )
+              if (typeof doc.data().wasCheckedForAlerts === 'undefined') {
+                deviceTokens.add(
+                  getDeviceTokensIfNotCheckedIn(doc.data())
+                )
+
+                admin.firestore().collection('users').doc(doc.id).set(
+                  { wasCheckedForAlerts: true },
+                  { merge: true }
+                )
+              } else if (!doc.data().wasCheckedForAlerts) {
+                deviceTokens.add(
+                  getDeviceTokensIfNotCheckedIn(doc.data())
+                )
+
+                admin.firestore().collection('users').doc(doc.id).update(
+                  { wasCheckedForAlerts: true }
+                )
+              }
             }
           )
 


### PR DESCRIPTION
Currently, Firebase Cloud Functions sends push notifications to all patient/member and standby/buddy every minute even if their device(s) have already been sent an alert.  Add a condition that checks whether a patient's/member's document has been checked since the last check-in.