### PR TITLE
Fix Errors Noticed in Simulator

### DIFF
--- a/redux/ActionThunks.js
+++ b/redux/ActionThunks.js
@@ -463,7 +463,11 @@ export const register = (creds) => (dispatch, getState) => {
       }
     )
     .then(
-      userCredential => dispatch(ActionCreators.registrationFulfilled(creds)),
+      userCredential => dispatch(
+        ActionCreators.registrationFulfilled(
+          { user: userCredential.user, creds: creds }
+        )
+      ),
       error => {
         var errorMessage = new Error(error.message)
         throw errorMessage
@@ -689,10 +693,12 @@ export const setListener = (email, isTest = false) => (dispatch, getState) => {
       listener => exists(listener)
         ? dispatch(
           ActionCreators.setListenerFulfilled(
-            getState().listeners.concat(listener)
+            getState().listener.listeners.concat(listener)
           )
         )
-        : dispatch(ActionCreators.setListenerFulfilled(getState().listeners)),
+        : dispatch(
+          ActionCreators.setListenerFulfilled(getState()().listener.listeners)
+        ),
       error => {
         var errorMessage = new Error(error.message)
         throw errorMessage
@@ -926,10 +932,10 @@ export const setTimer = (isTest = false) => (dispatch, getState) => {
       timer => exists(timer)
         ? dispatch(
           ActionCreators.setTimerFulfilled(
-            getState().timers.concat(timer)
+            getState().timer.timers.concat(timer)
           )
         )
-        : dispatch(ActionCreators.setTimerFulfilled(getState().timers)),
+        : dispatch(ActionCreators.setTimerFulfilled(getState().timer.timers)),
       error => {
         var errorMessage = new Error(error.message)
         throw errorMessage

--- a/redux/authReducer.js
+++ b/redux/authReducer.js
@@ -36,7 +36,7 @@ type Action = {
   errorMessage: string
 } | {
   type: typeof ActionTypes.REGISTRATION_FULFILLED,
-  user: { user: Object }
+  user: {| user: Object, creds: {| username: string, password: string |} |}
 } | {
   type: typeof ActionTypes.SIGNIN_REQUESTED
 } | {
@@ -44,7 +44,7 @@ type Action = {
   errorMessage: string
 } | {
   type: typeof ActionTypes.SIGNIN_FULFILLED,
-  user: { user: Object }
+  user: {| user: Object, creds: {| username: string, password: string |} |}
 } | {
   type: typeof ActionTypes.SIGNOUT_REQUESTED
 } | {
@@ -78,7 +78,7 @@ export const Auth = (
       return {
         ...state,
         errorMessage: '',
-        user: action.user
+        user: action.user.user
       }
 
     case ActionTypes.SIGNIN_REQUESTED:
@@ -97,7 +97,7 @@ export const Auth = (
       return {
         ...state,
         errorMessage: '',
-        user: action.user
+        user: action.user.user
       }
 
     case ActionTypes.SIGNOUT_REQUESTED:

--- a/redux/tokenReducer.js
+++ b/redux/tokenReducer.js
@@ -37,7 +37,7 @@ type Action = {
   errorMessage: string
 } | {
   type: typeof ActionTypes.REGISTRATION_FULFILLED,
-  userCredential: {| username: string, password: string |}
+  user: {| user: Object, creds: {| username: string, password: string |} |}
 } | {
   type: typeof ActionTypes.SIGNIN_REQUESTED
 } | {
@@ -45,7 +45,7 @@ type Action = {
   errorMessage: string
 } | {
   type: typeof ActionTypes.SIGNIN_FULFILLED,
-  userCredential: {| username: string, password: string |}
+  user: {| user: Object, creds: {| username: string, password: string |} |}
 } | {
   type: typeof ActionTypes.SIGNOUT_REQUESTED
 } | {
@@ -80,8 +80,8 @@ export const Token = (
       return {
         ...state,
         errorMessage: '',
-        username: action.userCredential.username,
-        password: action.userCredential.password
+        username: action.user.creds.username,
+        password: action.user.creds.password
       }
 
     case ActionTypes.SIGNIN_REQUESTED:
@@ -100,8 +100,8 @@ export const Token = (
       return {
         ...state,
         errorMessage: '',
-        username: action.userCredential.username,
-        password: action.userCredential.password
+        username: action.user.creds.username,
+        password: action.user.creds.password
       }
 
     case ActionTypes.SIGNOUT_REQUESTED:


### PR DESCRIPTION
Two errors were made when fixing flow-type errors, as follows:
- Getting state for timers and listeners should be for timer and
listener instead;
- The object returned after a sign-in include a user object and
credentials and should be accessed and typed in their respective
reducers as such.

Fix these errors.